### PR TITLE
fix: use 'encode' instead of 'compress'

### DIFF
--- a/en/network/local-network-tutorial/get-state-with-headless-graphql.md
+++ b/en/network/local-network-tutorial/get-state-with-headless-graphql.md
@@ -74,7 +74,7 @@ The value `6931323065` might not make sense at first glance since it’s a `hex`
 
 ![Hex Conversion Example](/images/network/state-hex.png)
 
-In `libplanet`, data is compressed using [Bencodex](https://github.com/planetarium/bencodex), which is why the value is surrounded by `i` and `e`. After conversion, you’ll see that the data represents `120`.
+In `libplanet`, data is encoded using [Bencodex](https://github.com/planetarium/bencodex), which is why the value is surrounded by `i` and `e`. After conversion, you’ll see that the data represents `120`.
 
 ::: tip :tada:
 Well done! You’ve just learned how to query real game data using Headless and gained an understanding of how blockchain data flows. Don’t worry if some concepts seem complex; it’s okay not to grasp everything immediately. Next, we’ll cover how to work with private keys.

--- a/ko/network/local-network-tutorial/get-state-with-headless-graphql.md
+++ b/ko/network/local-network-tutorial/get-state-with-headless-graphql.md
@@ -71,7 +71,7 @@ query {
 
 ![hex 변환 예시](/images/network/state-hex.png)
 
-`libplanet`에서는 데이터를 [Bencodex](https://github.com/planetarium/bencodex)를 통해 압축하므로, 앞뒤로 `i`와 `e`가 붙어 있으며, 변환 후 `120`이라는 데이터를 확인할 수 있습니다.
+`libplanet`에서는 데이터를 [Bencodex](https://github.com/planetarium/bencodex)로 인코딩하므로, 앞뒤로 `i`와 `e`가 붙어 있으며, 변환 후 `120`이라는 데이터를 확인할 수 있습니다.
 
 ::: tip :tada:
 수고하셨습니다! Headless를 사용해 실제 게임 데이터를 조회하며 블록체인 데이터 흐름을 이해해보았습니다. 어려운 개념들이 나왔지만, 모든 내용을 완벽히 이해하지 못해도 괜찮습니다. 다음으로는 private key에 대해 다루겠습니다.


### PR DESCRIPTION
The term [`Compression`](https://en.wikipedia.org/wiki/Data_compression) should be used for something like [`zstd`](https://github.com/facebook/zstd). As I know, the reason that Libplanet is using `Bencodex`, is not to compress data. So I replaced `compress` word with `encode`.