### PR TITLE
fix: correct link to `/ko/contributing`

### DIFF
--- a/.vitepress/config/ko.mts
+++ b/.vitepress/config/ko.mts
@@ -44,8 +44,8 @@ function nav(): DefaultTheme.NavItem[] {
     },
     {
       text: '기여',
-      link: '/contributing/getting-started',
-      activeMatch: '/contributing/'
+      link: '/ko/contributing/getting-started',
+      activeMatch: '/ko/contributing/'
     },
     {
       text: '포럼 트렁크',


### PR DESCRIPTION
This pull request fixes `기여` button in `모딩` page. Before this pull request, it navigates users to English page even if there is Korean contributing page.