### PR TITLE
Describe more services

### DIFF
--- a/en/contributing/getting-started.md
+++ b/en/contributing/getting-started.md
@@ -55,8 +55,29 @@ graph LR
         9c-unity-grpc-client[gRPC Client]
     end
     launcher-graphql-client -- GraphQL <--> headless-graphql-server
-    launcher -- Run --> 9c-unity
+    launcher -- Execute --> 9c-unity
+    launcher -- Send NCG to Odin/Heimdall --> 9c-relay-bridge
+    launcher -- Send NCG to Ethereum(WNCG) --> 9c-eth-bridge
+    9c-relay-bridge -- GraphQL --> headless-graphql-server
+    9c-eth-bridge -- GraphQL --> headless-graphql-server
     9c-unity-grpc-client -- gRPC <--> headless-grpc-server
+
+    9c-unity -- Fetch Market --> market-service
+    market-service[Market Service] -- GraphQL --> headless-graphql-server
+
+    9c-unity -- In App Purchase --> iap
+    iap[IAP Service] -- GraphQL --> headless-graphql-server
+    iap -- Send Assets to Heimdall --> 9c-relay-bridge
+
+    9c-unity -- Fetch Arena Ranking Data --> arena-service
+    arena-service[Arena Service] -- GraphQL --> headless-graphql-server
+
+    9c-unity -- Fetch World Boss Ranking Data --> world-boss-service
+    world-boss-service[World Boss Service] -- GraphQL --> headless-graphql-server
+
+    9c-unity -- Request Patrol Reward --> patrol-reward-service
+    patrol-reward-service[Patrol Reward Service] -- GraphQL --> headless-graphql-server
+
 ```
 
 The implementations of this launcher and the Unity client are `9c-launcher` and `NineChronicles`. The `9c-launcher` interacts with `NineChronicles.Headless` via the GraphQL client, and the Unity client interacts with `NineChronicles.Headless` via the gRPC client.

--- a/ko/contributing/getting-started.md
+++ b/ko/contributing/getting-started.md
@@ -55,8 +55,29 @@ graph LR
         9c-unity-grpc-client[gRPC Client]
     end
     launcher-graphql-client -- GraphQL <--> headless-graphql-server
-    launcher -- 실행 --> 9c-unity
+    launcher -- Execute --> 9c-unity
+    launcher -- Send NCG to Odin/Heimdall --> 9c-relay-bridge
+    launcher -- Send NCG to Ethereum(WNCG) --> 9c-eth-bridge
+    9c-relay-bridge -- GraphQL --> headless-graphql-server
+    9c-eth-bridge -- GraphQL --> headless-graphql-server
     9c-unity-grpc-client -- gRPC <--> headless-grpc-server
+
+    9c-unity -- Fetch Market --> market-service
+    market-service[Market Service] -- GraphQL --> headless-graphql-server
+
+    9c-unity -- In App Purchase --> iap
+    iap[IAP Service] -- GraphQL --> headless-graphql-server
+    iap -- Send Assets to Heimdall --> 9c-relay-bridge
+
+    9c-unity -- Fetch Arena Ranking Data --> arena-service
+    arena-service[Arena Service] -- GraphQL --> headless-graphql-server
+
+    9c-unity -- Fetch World Boss Ranking Data --> world-boss-service
+    world-boss-service[World Boss Service] -- GraphQL --> headless-graphql-server
+
+    9c-unity -- Request Patrol Reward --> patrol-reward-service
+    patrol-reward-service[Patrol Reward Service] -- GraphQL --> headless-graphql-server
+
 ```
 
 이 런처와 유니티 클라이언트의 구현체들이 `9c-launcher`와 `NineChronicles` 입니다. `9c-launcher`는 GraphQL 클라이언트를 통해 `NineChronicles.Headless`와 상호작용하며, 유니티 클라이언트는 gRPC 클라이언트를 통해 `NineChronicles.Headless`와 상호작용합니다.


### PR DESCRIPTION
This pull request makes the services overview graph in `contributing/getting-started` page to describe more services (like market-service, Ethereum bridge, etc)

<img width="850" alt="image" src="https://github.com/user-attachments/assets/0677e6aa-66fd-451c-8dc1-b24d000f3d70">
