### PR TITLE
Add GitHub button

### DIFF
--- a/en/index.md
+++ b/en/index.md
@@ -18,6 +18,9 @@ hero:
     - theme: alt
       text: 2024 Modathon
       link: /event/2024modathon
+    - theme: alt
+      text: GitHub
+      link: https://github.com/planetarium
 
 features:
   - icon: 🔗

--- a/ko/index.md
+++ b/ko/index.md
@@ -18,6 +18,9 @@ hero:
     - theme: alt
       text: 2024 Modathon
       link: /ko/event/2024modathon
+    - theme: alt
+      text: GitHub
+      link: https://github.com/planetarium
 
 features:
   - icon: 🔗

--- a/ko/index.md
+++ b/ko/index.md
@@ -9,7 +9,7 @@ hero:
     - theme: brand
       text: 모딩 시작하기
       link: /ko/modding/getting-started
-    - theme: brand
+    - theme: alt
       text: 나인크로니클은 무엇인가?
       link: /ko/general/what-is-nine-chronicles
     - theme: alt


### PR DESCRIPTION
# Motivation

I added GitHub button to guide visitors to Planetarium GitHub organization. And I also updated button style in Korean version (brand -> alt). See screenshots.

# Screenshots

## Before

### English
![image](https://github.com/user-attachments/assets/e7581f95-be8f-4485-81b7-eb091233a3ef)

### Korean
![image](https://github.com/user-attachments/assets/9ae554fa-ff48-4bc6-b027-30357c3a94c7)

## After

### English
![image](https://github.com/user-attachments/assets/d55cb4bc-fbb3-452c-ad7b-bd6865711637)

### Korean
![image](https://github.com/user-attachments/assets/4c0f515c-8882-4162-9d9d-19c635cabdad)
